### PR TITLE
Fix to source_generator to allow compatibility with OpenMC 0.15, and minor changes to CMakeLists.txt for dependencies.

### DIFF
--- a/parametric_plasma_source/CMakeLists.txt
+++ b/parametric_plasma_source/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 project(parametric_plasma_source)
 
+find_package(PythonLibs REQUIRED)
+include_directories(${PYTHON_INCLUDE_DIRS})
+
 set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 
 message(STATUS ${SRC_DIR})
@@ -59,10 +62,12 @@ if(OpenMC_FOUND)
 
   find_library(OPENMC_LIB openmc HINTS ${OPENMC_LIB_DIR} OPTIONAL)
 
+  find_package(HDF5 REQUIRED)
+
   if (OPENMC_LIB)
     set_target_properties(source_sampling PROPERTIES PREFIX "")
     set_target_properties(source_sampling PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    target_include_directories(source_sampling PUBLIC ${OPENMC_INC_DIR})
+    target_include_directories(source_sampling PUBLIC ${OPENMC_INC_DIR} ${HDF5_INCLUDE_DIRS})
     target_link_libraries(source_sampling ${OPENMC_LIB} gfortran)
   endif()
 
@@ -72,8 +77,6 @@ if(OpenMC_FOUND)
   )
 
   add_executable(source_generator ${source_generator_SOURCES})
-
-  find_package(HDF5 REQUIRED)
 
   set_target_properties(source_generator PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_include_directories(source_generator PUBLIC ${OPENMC_INC_DIR})

--- a/parametric_plasma_source/src/source_generator.cpp
+++ b/parametric_plasma_source/src/source_generator.cpp
@@ -141,7 +141,22 @@ int main(int argc, char* argv[])
   }
 
   std::cout << "Sampling source:" << std::endl;
-  openmc::model::external_sources.push_back(std::make_unique<openmc::CustomSourceWrapper>(path_source_library, source_parameters));
+  
+  // OpenMC 0.15 changed CustomSourceWrapper to CompiledSourceWrapper taking an pugixml node with two 
+  // attributes rather than the previous string for each attribute.
+  // openmc::model::external_sources.push_back(std::make_unique<openmc::CustomSourceWrapper>(path_source_library, source_parameters));
+  
+  pugi::xml_document doc;
+  pugi::xml_node node_root = doc.append_child("root");
+
+  pugi::xml_attribute pugi_attr_library = node_root.append_attribute("library");
+  pugi_attr_library.set_value(path_source_library.c_str());
+
+  pugi::xml_attribute pugi_attr_parameters = node_root.append_attribute("parameters");
+  pugi_attr_parameters.set_value(source_parameters.c_str());
+
+  openmc::model::external_sources.push_back(std::make_unique<openmc::CompiledSourceWrapper>(node_root));
+
   openmc::calculate_work();
   openmc::allocate_banks();
   openmc::initialize_source();


### PR DESCRIPTION
OpenMC v0.15 changes CustomSourceWrapper to CompiledSourceWrapper which takes a pugixml node with an attribute for each of the parameter strings path_source_library and  source_parameters, rather than the previous of passing both seperately as strings.

Minor addition to order of parametric_plasma_source/CMakeLists.txt to place the find_package for HDF5 higher up. Also the addition of find_package and include_directories for PythonLIbs. 